### PR TITLE
Feature/issue 25 rename titles

### DIFF
--- a/src/main/java/com/trivadis/tvdcc/validators/GLP.xtend
+++ b/src/main/java/com/trivadis/tvdcc/validators/GLP.xtend
@@ -48,13 +48,13 @@ class GLP extends PLSQLJavaValidator implements PLSQLCopValidator {
 			}
 			// register guidelines
 			guidelines.put(9001,
-				new PLSQLCopGuideline(9001, '''Global variables should start with 'g_'.''', MAJOR, UNDERSTANDABILITY,
+				new PLSQLCopGuideline(9001, '''Always prefix global variables with 'g_'.''', MAJOR, UNDERSTANDABILITY,
 					Remediation.createConstantPerIssue(1)))
 			guidelines.put(9002,
-				new PLSQLCopGuideline(9002, '''Local variables should start with 'l_'.''', MAJOR, UNDERSTANDABILITY,
+				new PLSQLCopGuideline(9002, '''Always prefix local variables with 'l_'.''', MAJOR, UNDERSTANDABILITY,
 					Remediation.createConstantPerIssue(1)))
 			guidelines.put(9003,
-				new PLSQLCopGuideline(9003, '''Parameters should start with 'p_'.''', MAJOR, UNDERSTANDABILITY,
+				new PLSQLCopGuideline(9003, '''Always prefix parameters with 'p_'.''', MAJOR, UNDERSTANDABILITY,
 					Remediation.createConstantPerIssue(1)))
 		}
 		return guidelines

--- a/src/main/java/com/trivadis/tvdcc/validators/SQLInjection.xtend
+++ b/src/main/java/com/trivadis/tvdcc/validators/SQLInjection.xtend
@@ -62,7 +62,7 @@ class SQLInjection extends PLSQLJavaValidator implements PLSQLCopValidator {
 			guidelines = new HashMap<Integer, PLSQLCopGuideline>()
 			// register guidelines
 			guidelines.put(9501,
-				new PLSQLCopGuideline(9501, '''Parameter used in string expression of dynamic SQL. Use asserted local variable instead.''', CRITICAL, SECURITY_FEATURES,
+				new PLSQLCopGuideline(9501, '''Never use parameter in string expression of dynamic SQL. Use asserted local variable instead.''', CRITICAL, SECURITY_FEATURES,
 					Remediation.createConstantPerIssue(1)))
 		}
 		return guidelines
@@ -255,7 +255,7 @@ class SQLInjection extends PLSQLJavaValidator implements PLSQLCopValidator {
 			newExpressions.putAll(expressions)
 			newExpressions.putAll(recursiveExpressions)
 			for (key : recursiveExpressions.keySet) {
-				if (expressions.get(key) == null) {
+				if (expressions.get(key) === null) {
 					check(recursiveExpressions.get(key), newExpressions)
 				}
 			}

--- a/src/main/java/com/trivadis/tvdcc/validators/TrivadisPlsqlNaming.xtend
+++ b/src/main/java/com/trivadis/tvdcc/validators/TrivadisPlsqlNaming.xtend
@@ -122,63 +122,63 @@ class TrivadisPlsqlNaming extends PLSQLJavaValidator implements PLSQLCopValidato
 			// register custom guidelines
 			guidelines.put(ISSUE_GLOBAL_VARIABLE_NAME,
 				new PLSQLCopGuideline(
-					ISSUE_GLOBAL_VARIABLE_NAME, '''Global variables should start with '«PREFIX_GLOBAL_VARIABLE_NAME»'.''',
+					ISSUE_GLOBAL_VARIABLE_NAME, '''Always prefix global variables with '«PREFIX_GLOBAL_VARIABLE_NAME»'.''',
 					MAJOR, UNDERSTANDABILITY, Remediation.createConstantPerIssue(1)))
 			guidelines.put(TrivadisPlsqlNaming.ISSUE_LOCAL_VARIABLE_NAME,
 				new PLSQLCopGuideline(TrivadisPlsqlNaming.
-					ISSUE_LOCAL_VARIABLE_NAME, '''Local variables should start with '«PREFIX_LOCAL_VARIABLE_NAME»'.''',
+					ISSUE_LOCAL_VARIABLE_NAME, '''Always prefix local variables with '«PREFIX_LOCAL_VARIABLE_NAME»'.''',
 					MAJOR, UNDERSTANDABILITY, Remediation.createConstantPerIssue(1)))
 			guidelines.put(TrivadisPlsqlNaming.ISSUE_CURSOR_NAME,
 				new PLSQLCopGuideline(TrivadisPlsqlNaming.
-					ISSUE_CURSOR_NAME, '''Cursors should start with '«PREFIX_CURSOR_NAME»'.''', MAJOR,
+					ISSUE_CURSOR_NAME, '''Always prefix cursors with '«PREFIX_CURSOR_NAME»'.''', MAJOR,
 					UNDERSTANDABILITY, Remediation.createConstantPerIssue(1)))
 			guidelines.put(TrivadisPlsqlNaming.ISSUE_RECORD_NAME,
 				new PLSQLCopGuideline(TrivadisPlsqlNaming.
-					ISSUE_RECORD_NAME, '''Records should start with '«PREFIX_RECORD_NAME»'.''', MAJOR,
+					ISSUE_RECORD_NAME, '''Always prefix records with '«PREFIX_RECORD_NAME»'.''', MAJOR,
 					UNDERSTANDABILITY, Remediation.createConstantPerIssue(1)))
 			guidelines.put(TrivadisPlsqlNaming.ISSUE_ARRAY_NAME,
 				new PLSQLCopGuideline(TrivadisPlsqlNaming.
-					ISSUE_ARRAY_NAME, '''Collection types (arrays/tables) should start with '«PREFIX_ARRAY_NAME»'.''',
+					ISSUE_ARRAY_NAME, '''Always prefix collection types (arrays/tables) with '«PREFIX_ARRAY_NAME»'.''',
 					MAJOR, UNDERSTANDABILITY, Remediation.createConstantPerIssue(1)))
 			guidelines.put(TrivadisPlsqlNaming.ISSUE_OBJECT_NAME,
 				new PLSQLCopGuideline(TrivadisPlsqlNaming.
-					ISSUE_OBJECT_NAME, '''Objects should start with '«PREFIX_OBJECT_NAME»'.''', MAJOR,
+					ISSUE_OBJECT_NAME, '''Always prefix objects with '«PREFIX_OBJECT_NAME»'.''', MAJOR,
 					UNDERSTANDABILITY, Remediation.createConstantPerIssue(1)))
 			guidelines.put(TrivadisPlsqlNaming.ISSUE_CURSOR_PARAMETER_NAME,
 				new PLSQLCopGuideline(TrivadisPlsqlNaming.
-					ISSUE_CURSOR_PARAMETER_NAME, '''Cursor parameters should start with '«PREFIX_CURSOR_PARAMETER_NAME»'.''',
+					ISSUE_CURSOR_PARAMETER_NAME, '''Always prefix cursor parameters with '«PREFIX_CURSOR_PARAMETER_NAME»'.''',
 					MAJOR, UNDERSTANDABILITY, Remediation.createConstantPerIssue(1)))
 			guidelines.put(TrivadisPlsqlNaming.ISSUE_IN_PARAMETER_NAME,
 				new PLSQLCopGuideline(TrivadisPlsqlNaming.
-					ISSUE_IN_PARAMETER_NAME, '''In parameters should start with '«PREFIX_IN_PARAMETER_NAME»'.''', MAJOR,
+					ISSUE_IN_PARAMETER_NAME, '''Always prefix in parameters with '«PREFIX_IN_PARAMETER_NAME»'.''', MAJOR,
 					UNDERSTANDABILITY, Remediation.createConstantPerIssue(1)))
 			guidelines.put(TrivadisPlsqlNaming.ISSUE_OUT_PARAMETER_NAME,
 				new PLSQLCopGuideline(TrivadisPlsqlNaming.
-					ISSUE_OUT_PARAMETER_NAME, '''Out parameters should start with '«PREFIX_OUT_PARAMETER_NAME»'.''',
+					ISSUE_OUT_PARAMETER_NAME, '''Always prefix out parameters with '«PREFIX_OUT_PARAMETER_NAME»'.''',
 					MAJOR, UNDERSTANDABILITY, Remediation.createConstantPerIssue(1)))
 			guidelines.put(TrivadisPlsqlNaming.ISSUE_IN_OUT_PARAMETER_NAME,
 				new PLSQLCopGuideline(TrivadisPlsqlNaming.
-					ISSUE_IN_OUT_PARAMETER_NAME, '''In/out parameters should start with '«PREFIX_IN_OUT_PARAMETER_NAME»'.''',
+					ISSUE_IN_OUT_PARAMETER_NAME, '''Always prefix in/out parameters with '«PREFIX_IN_OUT_PARAMETER_NAME»'.''',
 					MAJOR, UNDERSTANDABILITY, Remediation.createConstantPerIssue(1)))
 			guidelines.put(TrivadisPlsqlNaming.ISSUE_RECORD_TYPE_NAME,
 				new PLSQLCopGuideline(TrivadisPlsqlNaming.
-					ISSUE_RECORD_TYPE_NAME, '''Record Type definitions should start with '«PREFIX_RECORD_TYPE_NAME»' and end with '«SUFFIX_RECORD_TYPE_NAME»'.''',
+					ISSUE_RECORD_TYPE_NAME, '''Always prefix record type definitions with '«PREFIX_RECORD_TYPE_NAME»' and add the suffix '«SUFFIX_RECORD_TYPE_NAME»'.''',
 					MAJOR, UNDERSTANDABILITY, Remediation.createConstantPerIssue(1)))
 			guidelines.put(TrivadisPlsqlNaming.ISSUE_ARRAY_TYPE_NAME,
 				new PLSQLCopGuideline(TrivadisPlsqlNaming.
-					ISSUE_ARRAY_TYPE_NAME, '''Collection Type definitions (arrays/tables) should start with '«PREFIX_ARRAY_TYPE_NAME»' and end with '«SUFFIX_ARRAY_TYPE_NAME»'.''',
+					ISSUE_ARRAY_TYPE_NAME, '''Always prefix collection type definitions (arrays/tables) with '«PREFIX_ARRAY_TYPE_NAME»' and add the suffix '«SUFFIX_ARRAY_TYPE_NAME»'.''',
 					MAJOR, UNDERSTANDABILITY, Remediation.createConstantPerIssue(1)))
 			guidelines.put(TrivadisPlsqlNaming.ISSUE_EXCEPTION_NAME,
 				new PLSQLCopGuideline(TrivadisPlsqlNaming.
-					ISSUE_EXCEPTION_NAME, '''Exceptions should start with '«PREFIX_EXCEPTION_NAME»'.''', MAJOR,
+					ISSUE_EXCEPTION_NAME, '''Always prefix exceptions with '«PREFIX_EXCEPTION_NAME»'.''', MAJOR,
 					UNDERSTANDABILITY, Remediation.createConstantPerIssue(1)))
 			guidelines.put(TrivadisPlsqlNaming.ISSUE_CONSTANT_NAME,
 				new PLSQLCopGuideline(TrivadisPlsqlNaming.
-					ISSUE_CONSTANT_NAME, '''Constants should start with '«PREFIX_CONSTANT_NAME»'.''', MAJOR,
+					ISSUE_CONSTANT_NAME, '''Always prefix constants with '«PREFIX_CONSTANT_NAME»'.''', MAJOR,
 					UNDERSTANDABILITY, Remediation.createConstantPerIssue(1)))
 			guidelines.put(TrivadisPlsqlNaming.ISSUE_SUBTYPE_NAME,
 				new PLSQLCopGuideline(TrivadisPlsqlNaming.
-					ISSUE_SUBTYPE_NAME, '''Subtypes should end with '«SUFFIX_SUBTYPE_NAME»'.''', MAJOR,
+					ISSUE_SUBTYPE_NAME, '''Always prefix subtypes with '«SUFFIX_SUBTYPE_NAME»'.''', MAJOR,
 					UNDERSTANDABILITY, Remediation.createConstantPerIssue(1)))
 		}
 		return guidelines

--- a/src/test/java/com/trivadis/tvdcc/validators/tests/AbstractValidatorTest.xtend
+++ b/src/test/java/com/trivadis/tvdcc/validators/tests/AbstractValidatorTest.xtend
@@ -29,8 +29,12 @@ import org.eclipse.emf.common.util.URI
 import org.eclipse.xtext.resource.XtextResource
 import org.eclipse.xtext.resource.XtextResourceSet
 import org.eclipse.xtext.validation.CheckMode
+import static org.hamcrest.core.AnyOf.*
+import static org.hamcrest.core.StringStartsWith.*
 import org.junit.AfterClass
+import org.junit.Assert
 import org.junit.BeforeClass
+import org.junit.Test
 
 abstract class AbstractValidatorTest {
 
@@ -62,6 +66,18 @@ abstract class AbstractValidatorTest {
 			if (Files.exists(Paths.get(FULL_PROPERTIES_FILE_NAME))) {
 				Files.delete(Paths.get(FULL_PROPERTIES_FILE_NAME))
 			}
+		}
+	}
+	
+	@Test
+	def void guidelineTitleStartsWithKeyword() {
+		val guidelines = getValidator().guidelines.values.filter[it.id >= 9000]
+		for (g : guidelines) {
+			Assert.assertThat(
+				'"' + g.msg + "' does not start with keyword",
+				g.msg,
+				anyOf(startsWith("Always"), startsWith("Never"), startsWith("Avoid"), startsWith("Try"))
+			)
 		}
 	}
 

--- a/src/test/java/com/trivadis/tvdcc/validators/tests/GLPTest.xtend
+++ b/src/test/java/com/trivadis/tvdcc/validators/tests/GLPTest.xtend
@@ -64,7 +64,7 @@ class GLPTest extends AbstractValidatorTest {
 		Assert.assertEquals(32, issue1.column)
 		Assert.assertEquals(1, issue1.length)
 		Assert.assertEquals("G-9003", issue1.code)
-		Assert.assertEquals("G-9003: Parameters should start with 'p_'.", issue1.message)
+		Assert.assertEquals("G-9003: Always prefix parameters with 'p_'.", issue1.message)
 		Assert.assertEquals("a IN INTEGER", issue1.data.get(0))
 		// b
 		val issue2 = issues.get(1)
@@ -72,7 +72,7 @@ class GLPTest extends AbstractValidatorTest {
 		Assert.assertEquals(46, issue2.column)
 		Assert.assertEquals(1, issue2.length)
 		Assert.assertEquals("G-9003", issue2.code)
-		Assert.assertEquals("G-9003: Parameters should start with 'p_'.", issue2.message)
+		Assert.assertEquals("G-9003: Always prefix parameters with 'p_'.", issue2.message)
 		Assert.assertEquals("b IN VARCHAR2", issue2.data.get(0))
 		// c
 		val issue3 = issues.get(2)
@@ -80,7 +80,7 @@ class GLPTest extends AbstractValidatorTest {
 		Assert.assertEquals(4, issue3.column)
 		Assert.assertEquals(1, issue3.length)
 		Assert.assertEquals("G-9002", issue3.code)
-		Assert.assertEquals("G-9002: Local variables should start with 'l_'.", issue3.message)
+		Assert.assertEquals("G-9002: Always prefix local variables with 'l_'.", issue3.message)
 		Assert.assertEquals("c INTEGER;", issue3.data.get(0))
 	}
 
@@ -146,7 +146,7 @@ class GLPTest extends AbstractValidatorTest {
 		Assert.assertEquals(4, issue1.column)
 		Assert.assertEquals(15, issue1.length)
 		Assert.assertEquals("G-9001", issue1.code)
-		Assert.assertEquals("G-9001: Global variables should start with 'g_'.", issue1.message)
+		Assert.assertEquals("G-9001: Always prefix global variables with 'g_'.", issue1.message)
 		Assert.assertEquals("global_variable INTEGER;", issue1.data.get(0))
 	}
 


### PR DESCRIPTION
Closes #25 - Rename guideline titles to match the convention of the PL/SQL & SQL Coding Guidelines